### PR TITLE
[BUGFIX] Fix external redirects with custom pageNotFound handler

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -47,7 +47,7 @@ class ConfigurationUtility
         }
         // Fallback on default configuration
         $configuration = static::getConfiguration();
-        return (int)($configuration['defaultRootPageId'] ?: ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['rootpage_id'] ?: 1));
+        return (int)($configuration['defaultRootPageId'] ?: ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['rootpage_id'] ?: 0));
     }
 
     /**


### PR DESCRIPTION
Fix external redirects in multi-page, multi-domain setups with custom pageNotFound handlers.
Previously, external redirects for the non-default page would fail, as the creation of the fake TSFE would run into the custom pageNotFound handler. 
Configuration of the defaultRootPageId is not an option in this scenario, as the possible root page ids depend on the domain. Therefore we can use the TSFE feature to identify the target page by domain. 